### PR TITLE
Fix slugs so they refer to filepaths

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -65,29 +65,29 @@ exports.createPages = async ({ graphql, actions, reporter }) => {
   // `context` is available in the template as a prop and as a variable in GraphQL
 
   if (notes.length > 0) {
-    notes
-      .filter(note => note.headings.length > 0)
-      .forEach((note, index) => {
-        // TODO: Add next & previous note functionality
-        const previousPostId = index === 0 ? null : notes[index - 1].id;
-        const nextPostId = index === notes.length - 1 ? null : notes[index + 1].id;
-        //TODO: Create script to find notes without valid heading titles
-        const title = transformTitleToPath(note.headings[0].value);
-        const pagePath = transformTitleToPath(title);
-        console.log(title);
+    notes.forEach((note, noteIndex) => {
+      // TODO: Add next & previous note functionality
+      const previousPostId = noteIndex === 0 ? null : notes[noteIndex - 1].id;
+      const nextPostId = noteIndex === notes.length - 1 ? null : notes[noteIndex + 1].id;
+      const notePath = `/notes${note.fields.slug}`;
+      let title = 'untitled';
+      if (note.headings.count > 0) {
+        if (note.headings[0].value) { title = note.headings[0].value; }
+      }
 
-        createPage({
-        // path: notes.fields.slug,
-          path: `/notes/${pagePath}`,
-          component: noteTemplate,
-          context: {
-            id: note.id,
-            title: title,
-            previousPostId,
-            nextPostId,
-          },
-        });
+      console.log(path);
+
+      createPage({
+        path: notePath,
+        component: noteTemplate,
+        context: {
+          id: note.id,
+          title: title,
+          previousPostId,
+          nextPostId,
+        },
       });
+    });
   }
 
   // Extract tag data from query
@@ -112,7 +112,7 @@ exports.onCreateNode = ({ node, actions, getNode }) => {
   const { createNodeField } = actions;
 
   if (node.internal.type === 'MarkdownRemark') {
-    const value = createFilePath({ node, getNode });
+    const value = createFilePath({ node, getNode, trailingSlash: false });
 
     // TODO: Investigate based on issue # 13 whether slug in this context is a filename
     createNodeField({

--- a/src/templates/tags.tsx
+++ b/src/templates/tags.tsx
@@ -39,12 +39,12 @@ const Tags: FC<TagsProps> = ({ pageContext, data }) => {
       <h1>{tagHeader}</h1>
       <ul>
         {edges.map(({ node }) => {
-          const slug = transformTitleToPath(node.fields.slug);
+          const slug = node.fields.slug;
+          const path = `/notes${slug}`;
           const title = node.headings[0].value || 'untitled';
-          const path = transformTitleToPath(title);
           return (
             <li key={slug}>
-              <Link to={`/notes/${path}`}>{title}</Link>
+              <Link to={path}>{title}</Link>
             </li>
           );
         })}


### PR DESCRIPTION
* Issue #13
* Slugs are now created via gatsby-source-filesystem's...
  * createFilePath * the slug is now entirely determined by filepath for fs notes * this function now creates nodes of slugs w/o trailing slash
* Titles are now just created from headings
  * If root heading h1 doesn't exist it's just 'untitled'
* createPage
  * Now passes along a `path` param * template `notes/${slug}` as the path
* src/templates/tags.tsx
  * The template now uses slugs to create links * Now uses correct `/notes${slug}` path slug created page
  * Title is now ony determined by headings, untitled if n/e